### PR TITLE
Add write support for setup characteristic

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,11 @@
 This library offers a BLE API for the Viron and Halo series of AstralPool chlorinators and can be used to remote control pool pump and the chlorinator operation.
 
 It is the foundation for the HomeAssistant [Astral Pool Viron eQuilibrium Chlorinator](https://github.com/pbutterworth/astralpool_chlorinator) plugin.
+
+## New in this PR
+
+- `ChlorinatorSetupWrite` class — packs setup bytes for writing pH setpoint, chlorine output level and default manual speed
+- `async_write_setup()` method on `ChlorinatorAPI` — writes pH setpoint, chlorine output and default manual speed to `UUID_CHLORINATOR_SETUP`
+- `async_write_action()` extended with `period_minutes` parameter for `DisableAcidDosingForPeriod` action
+- Unit tests for `ChlorinatorSetupWrite` round-trip verification
+- Improved debug logging in `async_gatherdata()` — full coordinator data logged at debug level

--- a/pychlorinator/chlorinator.py
+++ b/pychlorinator/chlorinator.py
@@ -13,6 +13,7 @@ from .chlorinator_parsers import (
     ChlorinatorCapabilities,
     ChlorinatorSettings,
     ChlorinatorSetup,
+    ChlorinatorSetupWrite,
     ChlorinatorState,
     ChlorinatorStatistics,
     ChlorinatorTimers,
@@ -88,7 +89,7 @@ class ChlorinatorAPI:
         self._session_key = None
         self._result: dict[str, Any] | None = None
 
-    async def async_write_action(self, action: ChlorinatorActions):
+    async def async_write_action(self, action: ChlorinatorActions, period_minutes: int = 0):
         """Connect to the Chlorinator and write an action command to it."""
 
         client = await establish_connection(
@@ -116,11 +117,68 @@ class ChlorinatorAPI:
             await client.read_gatt_char(UUID_LIGHTING_SETUP)
             await client.read_gatt_char(UUID_LIGHTING_TIMERS)
 
-            data = ChlorinatorAction(action).__bytes__()
+            data = ChlorinatorAction(action, period_minutes).__bytes__()
             _LOGGER.debug("Data to write: %s", data.hex())
             data = encrypt_characteristic(data, self._session_key)
             _LOGGER.debug("Encrypted data to write: %s", data.hex())
             await client.write_gatt_char(UUID_CHLORINATOR_APP_ACTION, data)
+        finally:
+            await client.disconnect()
+
+    async def async_write_setup(
+        self,
+        ph_control_setpoint: float = None,
+        chlorine_control_setpoint: int = None,
+        default_manual_on_speed = None,
+    ):
+        """Connect to the Chlorinator and write setup characteristic."""
+
+        client = await establish_connection(
+            BleakClientWithServiceCache,
+            self._ble_device,
+            self._ble_device.name or "Unknown Device",
+            max_attempts=4,
+        )
+
+        try:
+            self._session_key = await client.read_gatt_char(UUID_SLAVE_SESSION_KEY)
+            _LOGGER.debug("Got session key: %s", self._session_key.hex())
+
+            mac = encrypt_mac_key(self._session_key, bytes(self._access_code, "utf_8"))
+            _LOGGER.debug("Mac key to write: %s", mac)
+            await client.write_gatt_char(UUID_MASTER_AUTHENTICATION, mac)
+
+            # Read all characteristics to ensure authenticated
+            await client.read_gatt_char(UUID_CHLORINATOR_STATE)
+            await client.read_gatt_char(UUID_CHLORINATOR_TIMERS)
+            await client.read_gatt_char(UUID_CHLORINATOR_SETTINGS)
+            await client.read_gatt_char(UUID_LIGHTING_STATE)
+            await client.read_gatt_char(UUID_LIGHTING_SETUP)
+            await client.read_gatt_char(UUID_LIGHTING_TIMERS)
+
+            # Read current setup to preserve existing values
+            raw = decrypt_characteristic(
+                await client.read_gatt_char(UUID_CHLORINATOR_SETUP), self._session_key
+            )
+            current = ChlorinatorSetup(raw)
+
+            # Override only the values that were passed in
+            new_ph = ph_control_setpoint if ph_control_setpoint is not None else current.ph_control_setpoint
+            new_chlorine = chlorine_control_setpoint if chlorine_control_setpoint is not None else current.chlorine_control_setpoint
+            new_speed = default_manual_on_speed if default_manual_on_speed is not None else current.default_manual_on_speed
+
+            setup = ChlorinatorSetupWrite(
+                default_manual_on_speed=new_speed,
+                ph_control_setpoint=new_ph,
+                chlorine_control_setpoint=new_chlorine,
+                flags=current.flags,
+            )
+
+            data = bytes(setup)
+            _LOGGER.debug("Setup data to write: %s", data.hex())
+            data = encrypt_characteristic(data, self._session_key)
+            _LOGGER.debug("Encrypted setup data to write: %s", data.hex())
+            await client.write_gatt_char(UUID_CHLORINATOR_SETUP, data)
         finally:
             await client.disconnect()
 
@@ -162,7 +220,7 @@ class ChlorinatorAPI:
                 )
                 self._result.update(vars(parser(databytes)))
 
-            _LOGGER.debug(self._result)
+            _LOGGER.debug("Full coordinator data: %s", self._result)
         finally:
             await client.disconnect()
 

--- a/pychlorinator/chlorinator_parsers.py
+++ b/pychlorinator/chlorinator_parsers.py
@@ -242,6 +242,34 @@ class ChlorinatorSetup:
         )
 
 
+class ChlorinatorSetupWrite:
+    """Class to write Chlorinator Setup characteristic"""
+
+    fmt = "@BBHB"
+
+    def __init__(
+        self,
+        default_manual_on_speed: SpeedLevels,
+        ph_control_setpoint: float,
+        chlorine_control_setpoint: int,
+        flags: int,
+    ) -> None:
+        self.default_manual_on_speed = default_manual_on_speed
+        self.ph_control_setpoint = ph_control_setpoint
+        self.chlorine_control_setpoint = chlorine_control_setpoint
+        self.flags = flags
+
+    def __bytes__(self):
+        data = struct.pack(
+            self.fmt,
+            self.default_manual_on_speed.value,
+            int(self.ph_control_setpoint * 10),
+            self.chlorine_control_setpoint,
+            self.flags,
+        )
+        # Pad to 20 bytes to match characteristic length expected by AES encryption
+        return data.ljust(20, b'\x00')
+
 class ChlorinatorState:
     """Parser class for the Chlorinator State characteristic"""
 

--- a/tests/test_chlorinator_setup_write.py
+++ b/tests/test_chlorinator_setup_write.py
@@ -1,0 +1,74 @@
+"""Tests for ChlorinatorSetupWrite"""
+
+from pychlorinator.chlorinator_parsers import (
+    ChlorinatorSetup,
+    ChlorinatorSetupWrite,
+    SpeedLevels,
+)
+
+
+def make_setup_bytes(speed: int, ph: int, chlorine: int, flags: int) -> bytes:
+    """Helper to create raw setup bytes matching the @BBHB struct format"""
+    import struct
+    return struct.pack("@BBHB", speed, ph, chlorine, flags) + bytes(16)  # pad to 20 bytes
+
+
+def test_roundtrip_ph_setpoint():
+    """Test that writing and reading pH setpoint round-trips correctly"""
+    # Simulate current device state: speed=Medium, pH=8.0, chlorine=650, flags=0
+    raw = make_setup_bytes(speed=1, ph=80, chlorine=650, flags=0)
+    current = ChlorinatorSetup(raw)
+
+    assert current.ph_control_setpoint == 8.0
+    assert current.chlorine_control_setpoint == 650
+    assert current.default_manual_on_speed == SpeedLevels.Medium
+
+    # Write new pH setpoint of 7.4
+    write = ChlorinatorSetupWrite(
+        default_manual_on_speed=current.default_manual_on_speed,
+        ph_control_setpoint=7.4,
+        chlorine_control_setpoint=current.chlorine_control_setpoint,
+        flags=current.flags,
+    )
+
+    # Read back the packed bytes
+    result = ChlorinatorSetup(bytes(write) + bytes(16))
+    assert result.ph_control_setpoint == 7.4
+    assert result.chlorine_control_setpoint == 650
+    assert result.default_manual_on_speed == SpeedLevels.Medium
+
+
+def test_roundtrip_chlorine_setpoint():
+    """Test that writing and reading chlorine setpoint round-trips correctly"""
+    raw = make_setup_bytes(speed=1, ph=72, chlorine=650, flags=0)
+    current = ChlorinatorSetup(raw)
+
+    write = ChlorinatorSetupWrite(
+        default_manual_on_speed=current.default_manual_on_speed,
+        ph_control_setpoint=current.ph_control_setpoint,
+        chlorine_control_setpoint=5,
+        flags=current.flags,
+    )
+
+    result = ChlorinatorSetup(bytes(write) + bytes(16))
+    assert result.chlorine_control_setpoint == 5
+    assert result.ph_control_setpoint == 7.2
+
+
+def test_preserves_unchanged_values():
+    """Test that only the target value changes, others are preserved"""
+    raw = make_setup_bytes(speed=2, ph=75, chlorine=700, flags=3)
+    current = ChlorinatorSetup(raw)
+
+    write = ChlorinatorSetupWrite(
+        default_manual_on_speed=current.default_manual_on_speed,
+        ph_control_setpoint=7.2,
+        chlorine_control_setpoint=current.chlorine_control_setpoint,
+        flags=current.flags,
+    )
+
+    result = ChlorinatorSetup(bytes(write) + bytes(16))
+    assert result.ph_control_setpoint == 7.2
+    assert result.chlorine_control_setpoint == 700
+    assert result.default_manual_on_speed == SpeedLevels.High
+    assert result.flags == 3


### PR DESCRIPTION
## Summary

Adds write support for the `UUID_CHLORINATOR_SETUP` (0x45000202) characteristic, enabling control of:
- pH setpoint
- Chlorine output level (manual mode, 0-8) / ORP target setpoint (automatic mode, mV)
- Default manual pump speed

Also extends `async_write_action()` with a `period_minutes` parameter to support `DisableAcidDosingForPeriod`.

## Changes

### New class: `ChlorinatorSetupWrite`
Packs setup bytes back into the `@BBHB` struct format expected by the device, with 20-byte padding required for AES ECB block alignment.

### New method: `ChlorinatorAPI.async_write_setup()`
- Authenticates using the same session key mechanism as `async_gatherdata()`
- Reads current setup before writing to preserve unchanged values
- Accepts optional `ph_control_setpoint`, `chlorine_control_setpoint` and `default_manual_on_speed` parameters

### Extended: `async_write_action()`
- Added optional `period_minutes: int = 0` parameter
- Used by `DisableAcidDosingForPeriod` action to specify inhibit duration

### Improved: debug logging in `async_gatherdata()`
- Changed `_LOGGER.debug(self._result)` to `_LOGGER.debug("Full coordinator data: %s", self._result)`
- Standard Python logging format with lazy evaluation
- Full coordinator data visible when `pychlorinator.chlorinator` debug logging enabled in HA configuration

## Testing
- Tested on Astral Pool Viron EQ25 via ESPHome BLE proxy
- Unit tests added for `ChlorinatorSetupWrite` round-trip byte packing
- pH setpoint write confirmed working
- Chlorine output write confirmed working (manual mode 0-8, automatic mode mV with ORP probe)
- Default manual speed write confirmed working
- Acid dosing inhibit period confirmed working

## Notes
- `chlorine_control_setpoint` serves dual purpose: 0-8 in manual mode, ORP mV target in automatic mode
- With ORP probe connected and `chlorine_control_type` = Automatic, valid range is `minimum_orp_setpoint` to `maximum_orp_setpoint` from capabilities (200-800 mV on EQ25)
- Raw ORP mV is not available from the BLE state characteristic — only categorised status (VeryVeryLow through VeryVeryHigh)
- To enable full coordinator data logging, add to HA `configuration.yaml`:
```yaml
  logger:
    logs:
      pychlorinator.chlorinator: debug
```
## Compatibility
- Tested on Viron EQ25 only
- The setup characteristic format (`@BBHB`) is assumed consistent across Viron series
- Other Viron models (V25, EQ35) should work but are untested — issue #16 confirms V25 read compatibility
- Halo series: `halochlorinator.py` is completely unchanged, no Halo impact

## Related
- pbutterworth/astralpool_chlorinator#9 — config_flow fix (independent, no dependency)
- pbutterworth/astralpool_chlorinator#10 — BLE lock and sensors (independent, no dependency)
- pbutterworth/astralpool_chlorinator#11 — write controls (depends on this PR)
- pbutterworth/astralpool_chlorinator#12 — configurable poll interval (depends on #11)