### PR TITLE
Update GitHub Actions to v4/v5 for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.8'  # or any specific Python version required for your project
 


### PR DESCRIPTION
## Summary

GitHub is deprecating Node.js 20 on Actions runners, affecting `actions/checkout@v2` and `actions/setup-python@v2`. Both will stop working on June 2nd, 2026.

## Changes
- `actions/checkout@v2` → `actions/checkout@v4`
- `actions/setup-python@v2` → `actions/setup-python@v5`

## References
- https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/