### PR TITLE
Pin Poetry version to 1.8.5 in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
-          version: latest
+          version: 1.8.5
           virtualenvs-in-project: true
 
       - name: Build and publish to PyPI


### PR DESCRIPTION
## Summary
Updated the Poetry installation step in the publish workflow to use a specific version instead of always pulling the latest version.

## Key Changes
- Changed Poetry version from `latest` to `1.8.5` in the GitHub Actions workflow configuration

## Details
This change pins the Poetry dependency to a specific version (1.8.5) rather than using the `latest` tag. This ensures consistent and reproducible builds across workflow runs, preventing potential issues from unexpected breaking changes in newer Poetry versions.

https://claude.ai/code/session_01Y9Mep28hijLvqF6QgxMXMK